### PR TITLE
Proxy fix

### DIFF
--- a/contracts/ProxyMaster.sol
+++ b/contracts/ProxyMaster.sol
@@ -21,14 +21,18 @@ contract ProxyMaster {
         external
         payable
     {
+        address _masterCopy = masterCopy;
         assembly {
-            let masterCopy := and(sload(0), 0xffffffffffffffffffffffffffffffffffffffff)
             calldatacopy(0, 0, calldatasize())
-            let success := delegatecall(not(0), masterCopy, 0, calldatasize(), 0, 0)
+            let success := delegatecall(not(0), _masterCopy, 0, calldatasize(), 0, 0)
             returndatacopy(0, 0, returndatasize())
             switch success
             case 0 { revert(0, returndatasize()) }
             default { return(0, returndatasize()) }
         }
     }
+}
+
+contract ProxiedMaster {
+    address masterCopy;
 }

--- a/contracts/TokenOWL.sol
+++ b/contracts/TokenOWL.sol
@@ -2,16 +2,14 @@ pragma solidity ^0.4.18;
 
 import "@gnosis.pm/gnosis-core-contracts/contracts/Utils/Math.sol";
 import "@gnosis.pm/gnosis-core-contracts/contracts/Tokens/StandardToken.sol";
+import "./ProxyMaster.sol";
 
-contract TokenOWL is StandardToken {
+contract TokenOWL is ProxiedMaster, StandardToken {
     using Math for *;
 
     string public constant name = "OWL Token";
     string public constant symbol = "OWL";
     uint8 public constant decimals = 18;
-
-
-    address masterCopy;
 
     struct masterCopyCountdownType {
         address masterCopy;

--- a/contracts/TokenOWLUpdate.sol
+++ b/contracts/TokenOWLUpdate.sol
@@ -2,15 +2,14 @@ pragma solidity ^0.4.18;
 
 import "@gnosis.pm/gnosis-core-contracts/contracts/Utils/Math.sol";
 import "@gnosis.pm/gnosis-core-contracts/contracts/Tokens/StandardToken.sol";
+import "./ProxyMaster.sol";
 
-contract TokenOWLUpdate is StandardToken {
+contract TokenOWLUpdate is ProxiedMaster, StandardToken {
     using Math for *;
 
     string public constant name = "OWL Token";
     string public constant symbol = "OWL";
     uint8 public constant decimals = 18;
-
-    address masterCopy;
 
     struct masterCopyCountdownType {
         address masterCopy;

--- a/test/test_proxy.js
+++ b/test/test_proxy.js
@@ -38,38 +38,38 @@ contract('TokenOWL - Proxy', (accounts) => {
   })
 
   it('masterCopy can\'t be updated before masterCopyCountdown was started', async () => {
-    assertIsCreator(master)
+    await assertIsCreator(master)
     await assertRejects(tokenOWL.updateMasterCopy({ from: master }), 'should reject as startMasterCopyCountdown wasn\'t yet called')
    })
 
   it('not creator can\'t call startMasterCopyCountdown', async () => {
-    assertIsNotCreator(notMaster)
+    await assertIsNotCreator(notMaster)
     await assertRejects(tokenOWL.startMasterCopyCountdown(tokenOWLNew.address, { from: notMaster }), 'should reject as caller isn\'t the creator')
   })
 
   it('can\'t call startMasterCopyCountdown with zero address', async () => {
-    assertIsCreator(master)
+    await assertIsCreator(master)
     await assertRejects(tokenOWL.startMasterCopyCountdown(0, { from: master }), 'should reject as caller isn\'t the creator')
   })
 
   it('creator can call startMasterCopyCountdown', async () => {
-    assertIsCreator(master)
+    await assertIsCreator(master)
     await tokenOWL.startMasterCopyCountdown(tokenOWLNew.address, { from: master })
   })
 
   it('creator can\'t update masterCopy before time limit', async () => {
-    assertIsCreator(master)
+    await assertIsCreator(master)
     await assertRejects(tokenOWL.updateMasterCopy({ from: master }), 'should reject as time hasn\t passed')
   })
 
   it('not creator can\'t update masterCopy', async () => {
     await wait(60 * 60 * 24 * 30)
-    assertIsNotCreator(notMaster)
+    await assertIsNotCreator(notMaster)
     await assertRejects(tokenOWL.updateMasterCopy({ from: notMaster }), 'should reject as caller isn\'t the creator')
   })
 
   it('creator can update masterCopy after time limit', async () => {
-    assertIsCreator(master)
+    await assertIsCreator(master)
     await tokenOWL.setMinter(minter) 
     const ans = await tokenOWL.updateMasterCopy({ from: master })
     tokenOWL = TokenOWLUpdate.at(ProxyMaster.address)


### PR DESCRIPTION
Check out this. Note that this PR is not in lieu of a review: I only looked at the mechanics for the proxy.

It's pretty tricky. Basically, with proxies, you will persist your storage at a location while swapping out the code. What this means is that the _layout_ of the storage must make sense to the incoming code. Also, with this proxy model, since the code which is delegatecalled lives at the _first_ storage slot of the address (this is why the code originally had an sload(0) for masterCopy, though I changed it to be more explicit), you must make sure the master copy accounts for this.

Storage is packed in the order of declaration. When multiple inheriting, storage variables are packed into slots from left superclass to right.

Ultimately, you must account for the storage layout being the same, usually by declaring every single storage variable in the same order. This is why the fix for this involves another class with an identical storage as the ProxyMaster, forcing the class to shift storage over one slot.

I was going to write a guide to doing this style of proxy at some point...