### PR TITLE
addition of ownership change functionality

### DIFF
--- a/contracts/TokenOWL.sol
+++ b/contracts/TokenOWL.sol
@@ -74,6 +74,16 @@ contract TokenOWL is ProxiedMaster, StandardToken {
         minter = newMinter;
     }
 
+
+    /// @dev change owner/creator of the contract. Only the creator/owner of this contract can call this.
+    /// @param newOwner The new address, which should become the owner
+    function setNewOwner(address newOwner)
+        public
+        onlyCreator()
+    {
+        creator = newOwner;
+    }
+
     /// @dev Mints OWL.
     /// @param to Address to which the minted token will be given
     /// @param amount Amount of OWL to be minted

--- a/test/test_owl.js
+++ b/test/test_owl.js
@@ -6,7 +6,7 @@ const TokenOWLProxy = artifacts.require('TokenOWLProxy')
 
 
 contract('TokenOWL', (accounts) => {
-  const [creator, minter, altMinter, OWLHolder, notOWLHolder, notApprover, contractConsumingOWL] = accounts
+  const [creator, minter, altMinter, OWLHolder, notOWLHolder, notApprover, contractConsumingOWL, newOwner] = accounts
   let tokenOWL
 
   before(async () => {
@@ -25,6 +25,22 @@ contract('TokenOWL', (accounts) => {
       await assertRejects(tokenOWL.setMinter(minter, { from: other }))
     }
   })
+
+it('allows only the creator/owner to change the owner', async () => {
+    assert.equal(await tokenOWL.creator.call(), creator)
+
+    await tokenOWL.setNewOwner(newOwner, { from: creator })
+    assert.equal(await tokenOWL.creator.call(), newOwner)
+
+    for(let other of [minter, OWLHolder, notOWLHolder]) {
+      await assertRejects(tokenOWL.setMinter(minter, { from: other }))
+    }
+
+    await tokenOWL.setNewOwner(creator, { from: newOwner })
+    assert.equal(await tokenOWL.creator.call(), creator)
+
+  })
+
 
   contract('minting', () => {
     before(async () => {


### PR DESCRIPTION
We would like to deploy the owl contracts from a usual account and later change the ownership to a multisig. For the ownership change, we need this little function in the smart contract