### PR TITLE
Fix migration in dx-daostack

### DIFF
--- a/src/migrations-truffle-1.5/4_deploy_OWL_airdrop.js
+++ b/src/migrations-truffle-1.5/4_deploy_OWL_airdrop.js
@@ -1,6 +1,6 @@
 const GNO_LOCK_PERIOD_IN_HOURS = 30 * 24 // 30 days
 
-async function migrate ({
+async function migrate({
   artifacts,
   deployer,
   network,
@@ -9,13 +9,13 @@ async function migrate ({
   const TokenOWL = artifacts.require('TokenOWL')
   const TokenOWLProxy = artifacts.require('TokenOWLProxy')
   const OWLAirdrop = artifacts.require('OWLAirdrop')
-  const { Math, TokenGNO } = _getDependencies(artifacts, network, deployer)
+  const { Math: MathLib, TokenGNO } = _getDependencies(artifacts, network, deployer)
 
-  await Math.deployed()
+  await MathLib.deployed()
   const tokenGno = await TokenGNO.deployed()
   await TokenOWL.deployed()
   const tokenOWLProxy = await TokenOWLProxy.deployed()
-  await deployer.link(Math, [ OWLAirdrop ])
+  await deployer.link(MathLib, [OWLAirdrop])
 
   const owlProxyAddress = tokenOWLProxy.address
   const gnoAddress = tokenGno.address
@@ -28,16 +28,16 @@ async function migrate ({
     OWLAirdrop,
     owlProxyAddress,
     gnoAddress,
-    gnoLockEndTime.getTime() / 1000
+    Math.floor(gnoLockEndTime.getTime() / 1000)
   )
 }
 
-function _getDefaultLockEndTime () {
+function _getDefaultLockEndTime() {
   const now = new Date()
   return new Date(now.getTime() + GNO_LOCK_PERIOD_IN_HOURS * 60 * 60 * 1000)
 }
 
-function _getDependencies (artifacts, network, deployer) {
+function _getDependencies(artifacts, network, deployer) {
   let Math, TokenGNO
   if (network === 'development') {
     Math = artifacts.require('Math')


### PR DESCRIPTION
`truffle@5.0.0-beta.2` doesn't automatically cast to int `gnoLockEndTime.getTime() / 1000`, which results in 
```
Error: "OWLAirdrop" -- invalid number value (arg="_endTime", coderType="uint256", value=1545825440.515).
```

This is essential for [dx-daostack#27](https://github.com/gnosis/dx-daostack/pull/27)