### PR TITLE
Fix for dx-daostack migrations

### DIFF
--- a/contracts/OWLAirdrop.sol
+++ b/contracts/OWLAirdrop.sol
@@ -4,7 +4,7 @@ import "@gnosis.pm/gno-token/contracts/TokenGNO.sol";
 import "./TokenOWL.sol";
 
 contract OWLAirdrop {
-    using Math for *;
+    using GnosisMath for *;
 
     TokenOWL public tokenOWL;
     TokenGNO public tokenGNO;

--- a/contracts/TokenOWL.sol
+++ b/contracts/TokenOWL.sol
@@ -5,7 +5,7 @@ import "@gnosis.pm/util-contracts/contracts/GnosisStandardToken.sol";
 import "@gnosis.pm/util-contracts/contracts/Proxy.sol";
 
 contract TokenOWL is Proxied, GnosisStandardToken {
-    using Math for *;
+    using GnosisMath for *;
 
     string public constant name = "OWL Token";
     string public constant symbol = "OWL";

--- a/contracts/TokenOWLProxy.sol
+++ b/contracts/TokenOWLProxy.sol
@@ -4,7 +4,7 @@ import "@gnosis.pm/util-contracts/contracts/GnosisStandardToken.sol";
 import "@gnosis.pm/util-contracts/contracts/Proxy.sol";
 
 contract TokenOWLProxy is Proxy, GnosisStandardToken {
-    using Math for *;
+    using GnosisMath for *;
 
     string public constant name = "OWL Token";
     string public constant symbol = "OWL";

--- a/src/migrations-truffle-4/3_deploy_OWL.js
+++ b/src/migrations-truffle-4/3_deploy_OWL.js
@@ -13,7 +13,7 @@ function migrate ({ artifacts, deployer, network, accounts, web3 }) {
 function _getDependencies (artifacts, network, deployer) {
   let Math
   if (network === 'development') {
-    Math = artifacts.require('Math')
+    Math = artifacts.require('GnosisMath')
   } else {
     const contract = require('truffle-contract')
     Math = contract(require('@gnosis.pm/util-contracts/build/contracts/Math'))

--- a/src/migrations-truffle-4/4_deploy_OWL_airdrop.js
+++ b/src/migrations-truffle-4/4_deploy_OWL_airdrop.js
@@ -45,7 +45,7 @@ function _getDefaultLockEndTime () {
 function _getDependencies (artifacts, network, deployer) {
   let Math, TokenGNO
   if (network === 'development') {
-    Math = artifacts.require('Math')
+    Math = artifacts.require('GnosisMath')
     TokenGNO = artifacts.require('TokenGNO')
   } else {
     const contract = require('truffle-contract')

--- a/src/migrations-truffle-5/3_deploy_OWL.js
+++ b/src/migrations-truffle-5/3_deploy_OWL.js
@@ -18,7 +18,7 @@ async function migrate ({ artifacts, deployer, network, accounts, web3 }) {
 function _getDependencies (artifacts, network, deployer) {
   let Math
   if (network === 'development') {
-    Math = artifacts.require('Math')
+    Math = artifacts.require('GnosisMath')
   } else {
     const contract = require('truffle-contract')
     Math = contract(require('@gnosis.pm/util-contracts/build/contracts/Math'))

--- a/src/migrations-truffle-5/4_deploy_OWL_airdrop.js
+++ b/src/migrations-truffle-5/4_deploy_OWL_airdrop.js
@@ -44,7 +44,7 @@ function _getDefaultLockEndTime() {
 function _getDependencies(artifacts, network, deployer) {
   let Math, TokenGNO
   if (network === 'development') {
-    Math = artifacts.require('Math')
+    Math = artifacts.require('GnosisMath')
     TokenGNO = artifacts.require('TokenGNO')
   } else {
     const contract = require('truffle-contract')

--- a/test/contracts/FakeToken.sol
+++ b/test/contracts/FakeToken.sol
@@ -4,7 +4,7 @@ import "@gnosis.pm/util-contracts/contracts/Math.sol";
 import "@gnosis.pm/util-contracts/contracts/GnosisStandardToken.sol";
 
 contract FakeToken is GnosisStandardToken {
-    using Math for *;
+    using GnosisMath for *;
 
     string public constant name = "Fake Token";
     string public constant symbol = "FAKE";

--- a/test/contracts/TokenOWLUpdateFixture.sol
+++ b/test/contracts/TokenOWLUpdateFixture.sol
@@ -5,7 +5,7 @@ import "@gnosis.pm/util-contracts/contracts/GnosisStandardToken.sol";
 import "@gnosis.pm/util-contracts/contracts/Proxy.sol";
 
 contract TokenOWLUpdateFixture is Proxied, GnosisStandardToken {
-    using Math for *;
+    using GnosisMath for *;
 
     string public constant name = "OWL Token";
     string public constant symbol = "OWL";

--- a/test/migrations/3_deploy_fake.js
+++ b/test/migrations/3_deploy_fake.js
@@ -1,4 +1,4 @@
-const MathLib = artifacts.require('Math')
+const MathLib = artifacts.require('GnosisMath')
 const FakeToken = artifacts.require('FakeToken')
 
 module.exports = function (deployer) {

--- a/test/test_airdrop.js
+++ b/test/test_airdrop.js
@@ -1,6 +1,6 @@
 const { wait } = require('@digix/tempo')(web3)
 const { assertRejects } = require('./utils.js')
-const MathLib = artifacts.require('Math')
+const MathLib = artifacts.require('GnosisMath')
 const TokenOWL = artifacts.require('TokenOWL')
 const TokenOWLProxy = artifacts.require('TokenOWLProxy')
 const FakeToken = artifacts.require('FakeToken')

--- a/test/test_proxy.js
+++ b/test/test_proxy.js
@@ -1,7 +1,7 @@
 
 const { wait } = require('@digix/tempo')(web3)
 const { assertRejects } = require('./utils.js')
-const MathLib = artifacts.require('Math')
+const MathLib = artifacts.require('GnosisMath')
 const TokenOWL = artifacts.require('TokenOWL')
 const TokenOWLUpdateFixture = artifacts.require('TokenOWLUpdateFixture')
 const TokenOWLProxy = artifacts.require('TokenOWLProxy')


### PR DESCRIPTION
Renames Math library to avoid name collisions
Required for [dx-daostack#41](https://github.com/gnosis/dx-daostack/pull/41)