### PR TITLE
Drop math

### DIFF
--- a/src/migrations-truffle-4/3_deploy_OWL.js
+++ b/src/migrations-truffle-4/3_deploy_OWL.js
@@ -1,28 +1,10 @@
 function migrate ({ artifacts, deployer, network, accounts, web3 }) {
   const TokenOWL = artifacts.require('TokenOWL')
   const TokenOWLProxy = artifacts.require('TokenOWLProxy')
-  const { Math } = _getDependencies(artifacts, network, deployer)
 
   return deployer
-    .then(() => Math.deployed())
-    .then(() => deployer.link(Math, [ TokenOWL, TokenOWLProxy ]))
     .then(() => deployer.deploy(TokenOWL))
     .then(() => deployer.deploy(TokenOWLProxy, TokenOWL.address))
-}
-
-function _getDependencies (artifacts, network, deployer) {
-  let Math
-  if (network === 'development') {
-    Math = artifacts.require('GnosisMath')
-  } else {
-    const contract = require('truffle-contract')
-    Math = contract(require('@gnosis.pm/util-contracts/build/contracts/Math'))
-    Math.setProvider(deployer.provider)
-  }
-
-  return {
-    Math
-  }
 }
 
 module.exports = migrate

--- a/src/migrations-truffle-4/4_deploy_OWL_airdrop.js
+++ b/src/migrations-truffle-4/4_deploy_OWL_airdrop.js
@@ -11,14 +11,12 @@ function migrate ({
   const TokenOWL = artifacts.require('TokenOWL')
   const TokenOWLProxy = artifacts.require('TokenOWLProxy')
   const OWLAirdrop = artifacts.require('OWLAirdrop')
-  const { Math, TokenGNO } = _getDependencies(artifacts, network, deployer)
+  const { TokenGNO } = _getDependencies(artifacts, network, deployer)
 
   return deployer
-    .then(() => Math.deployed())
     .then(() => TokenGNO.deployed())
     .then(() => TokenOWL.deployed())
     .then(() => TokenOWLProxy.deployed())
-    .then(() => deployer.link(Math, [ OWLAirdrop ]))
     .then(() => {
       const owlProxyAddress = TokenOWLProxy.address
       const gnoAddress = TokenGNO.address
@@ -43,20 +41,17 @@ function _getDefaultLockEndTime () {
 }
 
 function _getDependencies (artifacts, network, deployer) {
-  let Math, TokenGNO
+  let TokenGNO
   if (network === 'development') {
-    Math = artifacts.require('GnosisMath')
     TokenGNO = artifacts.require('TokenGNO')
   } else {
     const contract = require('truffle-contract')
-    Math = contract(require('@gnosis.pm/util-contracts/build/contracts/Math'))
     Math.setProvider(deployer.provider)
     TokenGNO = contract(require('@gnosis.pm/gno-token/build/contracts/TokenGNO'))
     TokenGNO.setProvider(deployer.provider)
   }
 
   return {
-    Math,
     TokenGNO
   }
 }

--- a/src/migrations-truffle-5/3_deploy_OWL.js
+++ b/src/migrations-truffle-5/3_deploy_OWL.js
@@ -1,33 +1,13 @@
 async function migrate ({ artifacts, deployer, network, accounts, web3 }) {
   const TokenOWL = artifacts.require('TokenOWL')
   const TokenOWLProxy = artifacts.require('TokenOWLProxy')
-  const { Math } = _getDependencies(artifacts, network, deployer)
-
-  console.log('Link Math lib to TokenOWL and TokenOWLProxy')
-  await Math.deployed()
-  await deployer.link(Math, [ TokenOWL, TokenOWLProxy ])
 
   console.log('Deploy TokenOWL')
-  const tokenOWL = await deployer.deploy(TokenOWL)
+  await deployer.deploy(TokenOWL)
 
   console.log('Deploy TokenOWLProxy')
-  console.log('  - owl master address: %s', tokenOWL.address)
-  await deployer.deploy(TokenOWLProxy, tokenOWL.address)
-}
-
-function _getDependencies (artifacts, network, deployer) {
-  let Math
-  if (network === 'development') {
-    Math = artifacts.require('GnosisMath')
-  } else {
-    const contract = require('truffle-contract')
-    Math = contract(require('@gnosis.pm/util-contracts/build/contracts/Math'))
-    Math.setProvider(deployer.provider)
-  }
-
-  return {
-    Math
-  }
+  console.log('  - owl master address: %s', TokenOWL.address)
+  await deployer.deploy(TokenOWLProxy, TokenOWL.address)
 }
 
 module.exports = migrate

--- a/src/migrations-truffle-5/4_deploy_OWL_airdrop.js
+++ b/src/migrations-truffle-5/4_deploy_OWL_airdrop.js
@@ -1,6 +1,6 @@
 const GNO_LOCK_PERIOD_IN_HOURS = 30 * 24 // 30 days
 
-async function migrate({
+async function migrate ({
   artifacts,
   deployer,
   network,
@@ -10,13 +10,11 @@ async function migrate({
   const TokenOWL = artifacts.require('TokenOWL')
   const TokenOWLProxy = artifacts.require('TokenOWLProxy')
   const OWLAirdrop = artifacts.require('OWLAirdrop')
-  const { Math: MathLib, TokenGNO } = _getDependencies(artifacts, network, deployer)
+  const { TokenGNO } = _getDependencies(artifacts, network, deployer)
 
-  await MathLib.deployed()
   const tokenGno = await TokenGNO.deployed()
   await TokenOWL.deployed()
   const tokenOWLProxy = await TokenOWLProxy.deployed()
-  await deployer.link(MathLib, [OWLAirdrop])
 
   const owlProxyAddress = tokenOWLProxy.address
   const gnoAddress = tokenGno.address
@@ -36,26 +34,23 @@ async function migrate({
   )
 }
 
-function _getDefaultLockEndTime() {
+function _getDefaultLockEndTime () {
   const now = new Date()
   return new Date(now.getTime() + GNO_LOCK_PERIOD_IN_HOURS * 60 * 60 * 1000)
 }
 
-function _getDependencies(artifacts, network, deployer) {
-  let Math, TokenGNO
+function _getDependencies (artifacts, network, deployer) {
+  let TokenGNO
   if (network === 'development') {
-    Math = artifacts.require('GnosisMath')
     TokenGNO = artifacts.require('TokenGNO')
   } else {
     const contract = require('truffle-contract')
-    Math = contract(require('@gnosis.pm/util-contracts/build/contracts/Math'))
-    Math.setProvider(deployer.provider)
+
     TokenGNO = contract(require('@gnosis.pm/gno-token/build/contracts/TokenGNO'))
     TokenGNO.setProvider(deployer.provider)
   }
 
   return {
-    Math,
     TokenGNO
   }
 }

--- a/src/truffle/changeOwlCreator.js
+++ b/src/truffle/changeOwlCreator.js
@@ -2,7 +2,7 @@
 /* eslint no-undef: "error" */
 
 const assert = require('assert')
-//const _web3 = require('web3')
+// const _web3 = require('web3')
 
 const GAS = 5e5 // 500K
 const DEFAULT_GAS_PRICE_GWEI = 5
@@ -33,7 +33,7 @@ var argv = require('yargs')
     type: 'boolean',
     default: false,
     describe: 'Dry run. Do not add the token pair, do just the validations.'
-  })  
+  })
   .help('h')
   .strict()
   .argv
@@ -63,7 +63,7 @@ async function changeOwner () {
 
     // Validations
     assert(web3.isAddress(newOwner), `The address ${newOwner} is not valid`)
-    assert.equal(account, creator, 'The account used to run the script must be the current owner of OWL')
+    assert.strictEqual(account, creator, 'The account used to run the script must be the current owner of OWL')
 
     if (newOwner !== creator) {
       if (dryRun) {

--- a/test/migrations/3_deploy_fake.js
+++ b/test/migrations/3_deploy_fake.js
@@ -1,7 +1,6 @@
-const MathLib = artifacts.require('GnosisMath')
+/* global artifacts */
 const FakeToken = artifacts.require('FakeToken')
 
 module.exports = function (deployer) {
-  deployer.link(MathLib, FakeToken)
   deployer.deploy(FakeToken)
 }

--- a/test/test_airdrop.js
+++ b/test/test_airdrop.js
@@ -1,13 +1,12 @@
+/* global artifacts, web3, contract, assert */
+
 const { fromWei } = web3.utils
 const { time, ether } = require('openzeppelin-test-helpers')
 const { assertRejects } = require('./utils.js')
-const MathLib = artifacts.require('GnosisMath')
 const TokenOWL = artifacts.require('TokenOWL')
 const TokenOWLProxy = artifacts.require('TokenOWLProxy')
 const FakeToken = artifacts.require('FakeToken')
 const OWLAirdrop = artifacts.require('OWLAirdrop')
-
-OWLAirdrop.link(MathLib)
 
 contract('OWLAirdrop', accounts => {
   const [creator, holder] = accounts

--- a/test/test_owl.js
+++ b/test/test_owl.js
@@ -1,3 +1,5 @@
+/* global artifacts, web3, contract, assert */
+
 const { assertRejects } = require('./utils.js')
 const { toWei } = web3.utils
 const { BN, ether } = require('openzeppelin-test-helpers')
@@ -6,7 +8,7 @@ const TokenOWLProxy = artifacts.require('TokenOWLProxy')
 const OWLAirdrop = artifacts.require('OWLAirdrop')
 
 contract('TokenOWL', accounts => {
-  const [creator, minter, altMinter, OWLHolder, notOWLHolder, notApprover, contractConsumingOWL, newOwner] = accounts
+  const [creator, minter, altMinter, OWLHolder, notOWLHolder,, contractConsumingOWL] = accounts
   let tokenOWL
   let owlAirdrop
 
@@ -29,7 +31,7 @@ contract('TokenOWL', accounts => {
   })
 
   it('allows only the creator/owner to change the owner', async () => {
-    const newOwner = altMinter;
+    const newOwner = altMinter
     assert.equal(await tokenOWL.creator.call(), creator)
 
     await tokenOWL.setNewOwner(newOwner, { from: creator })

--- a/test/test_proxy.js
+++ b/test/test_proxy.js
@@ -1,3 +1,5 @@
+/* global artifacts, contract, assert */
+
 const { time } = require('openzeppelin-test-helpers')
 const { assertRejects } = require('./utils.js')
 const TokenOWL = artifacts.require('TokenOWL')
@@ -66,7 +68,7 @@ contract('TokenOWL - Proxy', accounts => {
   it('creator can update masterCopy after time limit', async () => {
     await assertIsCreator(master)
     await tokenOWL.setMinter(minter)
-    const ans = await tokenOWL.updateMasterCopy({ from: master })
+    await tokenOWL.updateMasterCopy({ from: master })
     tokenOWL = await TokenOWLUpdateFixture.at(TokenOWLProxy.address)
 
     // testing that old variables are still available

--- a/test/test_proxy.js
+++ b/test/test_proxy.js
@@ -1,6 +1,5 @@
 const { time } = require('openzeppelin-test-helpers')
 const { assertRejects } = require('./utils.js')
-const MathLib = artifacts.require('GnosisMath')
 const TokenOWL = artifacts.require('TokenOWL')
 const TokenOWLUpdateFixture = artifacts.require('TokenOWLUpdateFixture')
 const TokenOWLProxy = artifacts.require('TokenOWLProxy')
@@ -12,7 +11,6 @@ contract('TokenOWL - Proxy', accounts => {
   const [ master, notMaster, minter ] = accounts
 
   before(async () => {
-    await TokenOWLUpdateFixture.link(MathLib)
     const ProxyMasterContract = await TokenOWLProxy.deployed()
     tokenOWL = await TokenOWL.at(ProxyMasterContract.address)
     // a new deployed TokenOWL to replace the old with

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,5 +1,7 @@
+/* global assert */
 const assertRejects = async (q, msg) => {
-  let res, catchFlag = false
+  let res
+  let catchFlag = false
   try {
     res = await q
     // checks if there was a Log event and its argument l contains string "R<number>"


### PR DESCRIPTION
Since solidity inlines internal library functions inside the contract code, there's no need to deploy and link Math library anymore.