### PR TITLE
add Transfer events to mint and burn

### DIFF
--- a/contracts/TokenOWL.sol
+++ b/contracts/TokenOWL.sol
@@ -76,6 +76,7 @@ contract TokenOWL is Proxied, GnosisStandardToken {
         balances[to] = balances[to].add(amount);
         totalTokens = totalTokens.add(amount);
         emit Minted(to, amount);
+        emit Transfer(address(0), to, amount);
     }
 
     /// @dev Burns OWL.
@@ -86,5 +87,6 @@ contract TokenOWL is Proxied, GnosisStandardToken {
         balances[user] = balances[user].sub(amount);
         totalTokens = totalTokens.sub(amount);
         emit Burnt(msg.sender, user, amount);
+        emit Transfer(user, address(0), amount);
     }
 }

--- a/test/test_owl.js
+++ b/test/test_owl.js
@@ -6,7 +6,7 @@ const TokenOWLProxy = artifacts.require('TokenOWLProxy')
 const OWLAirdrop = artifacts.require('OWLAirdrop')
 
 contract('TokenOWL', accounts => {
-  const [creator, minter, altMinter, OWLHolder, notOWLHolder, notApprover, contractConsumingOWL, newOwner] = accounts
+  const [creator, minter, altMinter, OWLHolder, OWLHolder2, notOWLHolder, notApprover, contractConsumingOWL, newOwner] = accounts
   let tokenOWL
   let owlAirdrop
 
@@ -58,6 +58,16 @@ contract('TokenOWL', accounts => {
       }
     })
 
+    it('emits a Transfer from address 0 event during a mint', async () => {
+      const mintTx = await tokenOWL.mintOWL(OWLHolder2, ether('1'), { from: minter })
+
+      const transferLog = mintTx.logs.find(({event}) => event === 'Transfer')
+      assert(transferLog, 'could not found a log of the Transfer event')
+      assert.equal(transferLog.args.from, '0x0000000000000000000000000000000000000000')
+      assert.equal(transferLog.args.to, OWLHolder2)
+      assert.equal(transferLog.args.value.valueOf(), 1e18)
+    })
+
     it('revokes minting privileges for old minter upon setting new minter', async () => {
       assert.equal(await tokenOWL.minter.call(), minter)
       await tokenOWL.setMinter(altMinter, { from: creator })
@@ -75,6 +85,7 @@ contract('TokenOWL', accounts => {
     before(async () => {
       await tokenOWL.setMinter(minter, { from: creator })
       await tokenOWL.mintOWL(OWLHolder, ether('1'), { from: minter })
+      await tokenOWL.mintOWL(OWLHolder2, ether('1'), { from: minter })
     })
 
     it('check that burning is not working, if allowance is not enough', async () => {
@@ -103,6 +114,16 @@ contract('TokenOWL', accounts => {
 
       assert.equal(balanceBefore - 10 ** 18, (await tokenOWL.balanceOf.call(OWLHolder)), 'balance not updated correctly')
       assert.equal(allowanceBefore - 10 ** 18, (await tokenOWL.allowance.call(OWLHolder, contractConsumingOWL)), 'allowance was not changed correctly')
+    })
+
+    it('emits a Transfer to address 0 event during a burn', async () => {
+      await tokenOWL.approve(minter, ether('1'), { from: OWLHolder2 })
+      const burnTx = await tokenOWL.burnOWL(OWLHolder2, ether('1'), { from: minter })
+      const transferLog = burnTx.logs.find(({event}) => event === 'Transfer')
+      assert(transferLog, 'could not found a log of the Transfer event')
+      assert.equal(transferLog.args.from, OWLHolder2)
+      assert.equal(transferLog.args.to, '0x0000000000000000000000000000000000000000')
+      assert.equal(transferLog.args.value.valueOf(), 1e18)
     })
   })
 })


### PR DESCRIPTION
This allows Etherscan to index minting and burning for better analytics.