### PR TITLE
Rearrange log for OWL token migration

### DIFF
--- a/src/migrations-truffle-5/3_deploy_OWL.js
+++ b/src/migrations-truffle-5/3_deploy_OWL.js
@@ -14,9 +14,8 @@ async function migrate ({ artifacts, deployer, network, accounts, web3 }) {
     `)
     return
   }
-
+  console.log('  - OWL master address: %s', TokenOWL.address)
   console.log('Deploy TokenOWLProxy')
-  console.log('  - owl master address: %s', TokenOWL.address)
   await deployer.deploy(TokenOWLProxy, TokenOWL.address)
 }
 


### PR DESCRIPTION
Before we were seeing

```
Deploy TokenOWL
Deploy TokenOWLProxy
  - owl master address: 0xf9D83a31EfCefd2390C90b49E45F952f50dea1fa
```
which was confusing. Now we will see

```
Deploy TokenOWL
  - OWL master address: 0xf9D83a31EfCefd2390C90b49E45F952f50dea1fa
Deploy TokenOWLProxy
```

Quick question: Should we also show the OWL proxy address? Or should we not even bother to log the proxy deployment?