### PR TITLE
[Easy] Version bump v3.0.3 to v3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/owl-token",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "The OWL token and related smart contracts",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/owl-token",
-  "version": "4.0.0",
+  "version": "3.1.0",
   "description": "The OWL token and related smart contracts",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/owl-token",
-  "version": "3.0.3",
+  "version": "4.0.0",
   "description": "The OWL token and related smart contracts",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Bumping to next major version because we have recently introduced xDAI version of the OWL token.

To summarize the release notes will appear as follows:

**NOTICE** that the releases here https://github.com/gnosis/owl-token/tags are not aligned with the current package.json and this is why we are going straight to v3.2.0 instead of v3.1.0


## Title

v3.2.0

## Description

- Bump eslint-utils from 1.3.1 to 1.4.3 (#25)
- Bump js-yaml from 3.12.1 to 3.14.0 (#28)
- Bump decompress from 4.2.0 to 4.2.1 (#29)
- [Easy] replace lost network deployment info (#37)
- Merge pull request #34 from gnosis/update_deploy_owl_log
- rearrange console log from OWL token migration
- [xOWL] deployment (#33)
- Rename Owl -> OWL to fix master
- update package-lock.json
- Bump truffle to support --config param
- Fix master build by compiling all contracts before running test
- Implement Bridge Token OWL (#32)
- Depend on tokenbridge contracts (#31)
- Prepare repo for solidity 0.4 bridge contract (#30)
- Merge pull request #27 from gnosis/yarn_upgrade
- [Easy] yarn upgrade
- Merge pull request #22 from gnosis/feature/test_owl_mastercopy_change